### PR TITLE
Add audio support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "aotuv_lancer_vorbis_sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "495ea2c3cc8dc08e9fb6ff470c9c90e44d4fbc648882a0bfaba13216daea4c3c"
+dependencies = [
+ "cc",
+ "ogg_next_sys",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,6 +909,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ogg"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5477016638150530ba21dec7caac835b29ef69b20865751d2973fce6be386cf1"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "ogg_next_sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac4af25868786f6ab24956a8496a1eca4b010f860b449596f523d19ee9f956ae"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1954,6 +1982,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "vorbis_rs"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513beb7a94438399e404b297592dad39e99dd5e39515ab66dfe9caa6fd18897a"
+dependencies = [
+ "aotuv_lancer_vorbis_sys",
+ "errno",
+ "getrandom",
+ "ogg_next_sys",
+ "thiserror",
+ "tinyvec",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2065,12 +2107,14 @@ dependencies = [
  "base64 0.22.1",
  "dotenv",
  "lazy_static",
+ "ogg",
  "regex",
  "serenity",
  "tokio",
  "tracing",
  "tracing-subscriber",
  "uiua",
+ "vorbis_rs",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,15 +912,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ogg"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5477016638150530ba21dec7caac835b29ef69b20865751d2973fce6be386cf1"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "ogg_next_sys"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2107,7 +2098,6 @@ dependencies = [
  "base64 0.22.1",
  "dotenv",
  "lazy_static",
- "ogg",
  "regex",
  "serenity",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ tokio = { version = "1.21.2", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 uiua = { version = "0.13.0-rc.2", default-features = false }
+
+vorbis_rs = "0.5.4"
+ogg = "0.9.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,3 @@ tracing-subscriber = "0.3.18"
 uiua = { version = "0.13.0-rc.2", default-features = false }
 
 vorbis_rs = "0.5.4"
-ogg = "0.9.1"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ quite limited, discord does not offer many much of the ansi spec).
 - [X] have `fmt` color glyphs
 - [X] have `fmt`'s colors look good
 - [X] Catch messages that are too long
-- [ ] Audio embeds (don't just crash)
+- [X] Audio embeds (don't just crash)
 - [ ] Image embeds (don't just crash)
 - [ ] Gif embeds (don't just crash)
 - [X] Short summary of function in `w! docs`

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -137,7 +137,7 @@ pub async fn handle_run(msg: Message, http: Arc<Http>, code: &str) {
         }
     };
 
-    let finalized_text = format!("Source:\n{source}\nReturns:\n```\n{displayed_string}\n```");
+    let finalized_text = format!("Source:\n{source}\nReturns:\n{displayed_string}");
     if finalized_text.len() > 1000 {
         send_message(msg, &http, "Message is way too long").await;
         return;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use tracing::{debug, event, info, instrument, trace, Level};
 use wawa::*;
 
 const SELF_HANDLE: LazyLock<String> =
-    LazyLock::new(|| dotenv::var("BOT_SELF_HANDLE").unwrap_or_else(|_| "@wawa#0280".into()));
+    LazyLock::new(|| dotenv::var("BOT_SELF_HANDLE").unwrap_or_else(|_| "wawa#0280".into()));
 const SELF_ID: LazyLock<u64> =
     LazyLock::new(|| match dotenv::var("BOT_SELF_ID").map(|str| str.parse()) {
         Ok(Ok(id)) => id,

--- a/src/uiuaizing.rs
+++ b/src/uiuaizing.rs
@@ -70,19 +70,6 @@ pub fn run_uiua(code: &str) -> Result<Vec<OutputItem>, String> {
     let mut runtime = Uiua::with_safe_sys().with_execution_limit(DEFAULT_EXECUTION_LIMIT);
     let exp_code = &format!("# Experimental!\n{code}");
 
-    let r = match runtime.run_str(exp_code) {
-        Ok(_c) => runtime
-            .take_stack()
-            .into_iter()
-            .take(10)
-            .map(|v| v.show())
-            .collect::<Vec<String>>()
-            .join("\n"),
-        Err(e) => {
-            format!("Error while running: {e} ")
-        }
-    };
-
     match runtime.run_str(exp_code) {
         Ok(_c) => {
             trace!(code, "Code ran successfully");

--- a/src/uiuaizing/encode.rs
+++ b/src/uiuaizing/encode.rs
@@ -1,0 +1,90 @@
+//! Modified functions from uiua's encoding logic:
+//! https://github.com/uiua-lang/uiua/blob/95aa14c99a47ccf83bf81433aa4015dd752c2834/src/algorithm/encode.rs
+//!
+//! uiua is licensed by Kaikalii under the MIT License:
+//!
+//! MIT License
+//!
+//! Copyright (c) 2023 Kaikalii
+//!
+//! Permission is hereby granted, free of charge, to any person obtaining a copy
+//! of this software and associated documentation files (the "Software"), to deal
+//! in the Software without restriction, including without limitation the rights
+//! to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//! copies of the Software, and to permit persons to whom the Software is
+//! furnished to do so, subject to the following conditions:
+//!
+//! The above copyright notice and this permission notice shall be included in all
+//! copies or substantial portions of the Software.
+//!
+//! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//! AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//! SOFTWARE.
+
+use uiua::Value;
+
+pub fn value_to_audio_channels(audio: &Value) -> Result<Vec<Vec<f32>>, String> {
+    // logic taken out of uiua's editor
+    // https://github.com/uiua-lang/uiua/blob/95aa14c99a47ccf83bf81433aa4015dd752c2834/pad/editor/src/utils.rs#L931-L932
+    // ...with an added check for # of channels and song length because users are evil and will exploit your bot at every given opportunity
+    if audio.rank() > 2 {
+        return Err(format!(
+            "Audio must be a rank 1 or 2 numeric array, but it is rank {}",
+            audio.rank()
+        ));
+    }
+    if !audio
+        .shape()
+        .last()
+        .is_some_and(|n| (44100 / 4..44100 * 60).contains(n))
+    {
+        return Err("Audio too short or too long".into());
+    }
+
+    if !matches!(&audio, Value::Num(arr) if arr.elements().all(|x| x.abs() <= 5.0)) {
+        return Err("Audio samples are too loud".into());
+    }
+
+    let interleaved: Vec<f32> = match audio {
+        Value::Num(nums) => nums
+            .row_slices()
+            .flatten()
+            .map(|&f| f as f32 * 0.5 + 0.5)
+            .collect(),
+        Value::Byte(byte) => byte
+            .row_slices()
+            .flatten()
+            .map(|&b| b as f32 * 0.5 + 0.5)
+            .collect(),
+        _ => return Err("Audio must be a numeric array".into()),
+    };
+    let (length, mut channels) = match audio.rank() {
+        1 => (interleaved.len(), vec![interleaved]),
+        2 => (
+            audio.row_len(),
+            interleaved
+                .chunks_exact(audio.row_len())
+                .map(|c| c.to_vec())
+                .collect(),
+        ),
+        _ => {
+            // validated at the start
+            unreachable!()
+        }
+    };
+    if channels.len() > 5 {
+        return Err(format!(
+            "Audio can have at most 5 channels, but its shape is {}",
+            audio.shape()
+        ));
+    }
+
+    if channels.is_empty() {
+        channels.push(vec![0.0; length]);
+    }
+    Ok(channels)
+}


### PR DESCRIPTION
Title. Uses [`vorbis_rs`](https://crates.io/crates/vorbis_rs/0.5.4) for OGG Vorbis encoding. Mirrors the uiua site behavior in terms of deciding whether a value is audio.

![image](https://github.com/user-attachments/assets/627b3f74-9ff8-46e1-804b-fced34d195a8)
